### PR TITLE
Do not write when reading input report

### DIFF
--- a/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.cpp
+++ b/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.cpp
@@ -162,7 +162,7 @@ IOReturn VoodooI2CELANTouchpadDriver::parse_ELAN_report() {
     UInt8 reportData[ETP_MAX_REPORT_LEN];
     memset(&reportData, 0, sizeof(reportData));
 
-    IOReturn retVal = read_raw_data(0, sizeof(reportData), reportData);
+    IOReturn retVal = api->readI2C(reportData, sizeof(reportData));
     if (retVal != kIOReturnSuccess) {
         IOLog("%s::%s Failed to handle input\n", getName(), device_name);
         return retVal;
@@ -325,12 +325,6 @@ IOReturn VoodooI2CELANTouchpadDriver::read_ELAN_cmd(UInt16 reg, UInt8* val) {
     return read_raw_16bit_data(reg, ETP_I2C_INF_LENGTH, val);
 }
 
-IOReturn VoodooI2CELANTouchpadDriver::read_raw_data(UInt8 reg, size_t len, UInt8* values) {
-    IOReturn retVal = kIOReturnSuccess;
-    retVal = api->writeReadI2C(&reg, 1, values, len);
-    return retVal;
-}
-
 IOReturn VoodooI2CELANTouchpadDriver::read_raw_16bit_data(UInt16 reg, size_t len, UInt8* values) {
     IOReturn retVal = kIOReturnSuccess;
     UInt16 buffer[] {
@@ -350,7 +344,7 @@ bool VoodooI2CELANTouchpadDriver::reset_device() {
     IOSleep(100);
     UInt8 val[256];
     UInt8 val2[3];
-    retVal = read_raw_data(0x00, ETP_I2C_INF_LENGTH, val);
+    retVal = api->readI2C(val, ETP_I2C_INF_LENGTH);
     if (retVal != kIOReturnSuccess) {
         IOLog("%s::%s Failed to get reset acknowledgement\n", getName(), device_name);
         return false;;

--- a/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
+++ b/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
@@ -133,14 +133,6 @@ class VoodooI2CELANTouchpadDriver : public IOService {
      * @return returns a IOReturn status of the reads (usually a representation of I2C bus)
      */
     IOReturn read_raw_16bit_data(UInt16 reg, size_t len, UInt8* values);
-    /* Reads raw data from the I2C bus
-     * @reg which 8bit register to read the data from
-     * @len the length of the @val buffer
-     * @vaue a buffer which is large enough to hold the data being read
-     *
-     * @return returns a IOReturn status of the reads (usually a representation of I2C bus)
-     */
-    IOReturn read_raw_data(UInt8 reg, size_t len, UInt8* values);
     /* Releases any allocated resources (called by stop)
      *
      */


### PR DESCRIPTION
Writing a zero here prevents ELAN touchpads working on some devices, such as the Dell Chromebook Enterprise 7410 (Drallion).
Replacing writeReadI2C with ReadI2C allows these devices to work while not breaking existing devices.